### PR TITLE
ONME-3861 Update DNS classes and DNS module to support interface name

### DIFF
--- a/features/lwipstack/LWIPStack.h
+++ b/features/lwipstack/LWIPStack.h
@@ -80,6 +80,12 @@ public:
          */
         virtual nsapi_connection_status_t get_connection_status() const;
 
+        /** Return netif interface name
+         *
+         * @return       netif name  eg "en0"
+        */
+        virtual char *get_interface_name(char *buf);
+
         /** Return MAC address of the network interface
          *
          * @return              MAC address as "V:W:X:Y:Z"
@@ -93,7 +99,7 @@ public:
          * @param    buflen     size of supplied buffer
          * @return              Pointer to a buffer, or NULL if the buffer is too small
          */
-        virtual char *get_ip_address(char *buf, nsapi_size_t buflen);
+        virtual char *get_ip_address(char *buf, nsapi_size_t buflen, const char *interface_name);
 
         /** Copies netmask of the network interface to user supplied buffer
          *
@@ -177,6 +183,7 @@ public:
         osSemaphoreId_t has_both_addr;
 #define HAS_BOTH_ADDR 4
 #endif
+        char _interface_name[NSAPI_INTERFACE_NAME_MAX_SIZE];
         char has_addr_state;
         nsapi_connection_status_t connected;
         bool dhcp_started;
@@ -253,7 +260,7 @@ public:
      *  @param address  Destination for the host address
      *  @return         0 on success, negative error code on failure
      */
-    virtual nsapi_error_t get_dns_server(int index, SocketAddress *address);
+    virtual nsapi_error_t get_dns_server(int index, SocketAddress *address, const char *interface_name);
 
     /** Get the local IP address
      *
@@ -521,7 +528,7 @@ private:
     static const ip_addr_t *get_ipv4_addr(const struct netif *netif);
     static const ip_addr_t *get_ipv6_addr(const struct netif *netif);
 
-    static void add_dns_addr(struct netif *lwip_netif);
+    static void add_dns_addr(struct netif *lwip_netif, const char *interface_name);
 
     /* Static arena of sockets */
     struct mbed_lwip_socket arena[MEMP_NUM_NETCONN];

--- a/features/lwipstack/lwip/src/api/lwip_tcpip.c
+++ b/features/lwipstack/lwip/src/api/lwip_tcpip.c
@@ -187,6 +187,7 @@ tcpip_inpkt(struct pbuf *p, struct netif *inp, netif_input_fn input_fn)
 
   msg->type = TCPIP_MSG_INPKT;
   msg->msg.inp.p = p;
+  msg->msg.inp.p->netif = inp;
   msg->msg.inp.netif = inp;
   msg->msg.inp.input_fn = input_fn;
   if (sys_mbox_trypost(&mbox, msg) != ERR_OK) {

--- a/features/lwipstack/lwip/src/core/ipv4/lwip_dhcp.c
+++ b/features/lwipstack/lwip/src/core/ipv4/lwip_dhcp.c
@@ -659,7 +659,7 @@ dhcp_handle_ack(struct netif *netif)
   for (n = 0; (n < LWIP_DHCP_PROVIDE_DNS_SERVERS) && dhcp_option_given(dhcp, DHCP_OPTION_IDX_DNS_SERVER + n); n++) {
     ip_addr_t dns_addr;
     ip_addr_set_ip4_u32(&dns_addr, lwip_htonl(dhcp_get_option_value(dhcp, DHCP_OPTION_IDX_DNS_SERVER + n)));
-    dns_setserver(n, &dns_addr);
+    dns_setserver(n, &dns_addr, netif);
   }
 #endif /* LWIP_DHCP_PROVIDE_DNS_SERVERS */
 }

--- a/features/lwipstack/lwip/src/core/ipv4/lwip_icmp.c
+++ b/features/lwipstack/lwip/src/core/ipv4/lwip_icmp.c
@@ -371,14 +371,15 @@ icmp_send_response(struct pbuf *p, u8_t type, u8_t code)
           IP_HLEN + ICMP_DEST_UNREACH_DATASIZE);
 
   ip4_addr_copy(iphdr_src, iphdr->src);
+
 #ifdef LWIP_HOOK_IP4_ROUTE_SRC
   {
     ip4_addr_t iphdr_dst;
     ip4_addr_copy(iphdr_dst, iphdr->dest);
-    netif = ip4_route_src(&iphdr_src, &iphdr_dst);
+    netif = ip4_route_src(&iphdr_src, &iphdr_dst, netif_get_name(p->netif));
   }
 #else
-  netif = ip4_route(&iphdr_src);
+  netif = ip4_route(&iphdr_src, netif_get_name(p->netif));
 #endif
   if (netif != NULL) {
     /* calculate checksum */

--- a/features/lwipstack/lwip/src/core/ipv6/lwip_icmp6.c
+++ b/features/lwipstack/lwip/src/core/ipv6/lwip_icmp6.c
@@ -311,7 +311,8 @@ icmp6_send_response(struct pbuf *p, u8_t code, u32_t data, u8_t type)
     ip6_addr_copy(reply_src_local, ip6hdr->dest);
     reply_dest = &reply_dest_local;
     reply_src = &reply_src_local;
-    netif = ip6_route(reply_src, reply_dest);
+
+    netif = ip6_route(reply_src, reply_dest, netif_get_name(p->netif));
     if (netif == NULL) {
       /* drop */
       pbuf_free(q);

--- a/features/lwipstack/lwip/src/core/ipv6/lwip_ip6.c
+++ b/features/lwipstack/lwip/src/core/ipv6/lwip_ip6.c
@@ -59,6 +59,7 @@
 #include "lwip/mld6.h"
 #include "lwip/debug.h"
 #include "lwip/stats.h"
+#include <string.h>
 
 #ifdef LWIP_HOOK_FILENAME
 #include LWIP_HOOK_FILENAME
@@ -81,11 +82,25 @@
  * @return the netif on which to send to reach dest
  */
 struct netif *
-ip6_route(const ip6_addr_t *src, const ip6_addr_t *dest)
+ip6_route(const ip6_addr_t *src, const ip6_addr_t *dest, const char *interface_name)
 {
   struct netif *netif;
   s8_t i;
 
+  if(interface_name !=NULL) {
+    /* iterate through netifs */
+
+    for (netif = netif_list; netif != NULL; netif = netif->next) {
+      if (!netif_is_up(netif) || !netif_is_link_up(netif)) {
+        continue;
+      }
+      /* interface name  matches? */
+      if (!strcmp(netif_get_name(netif), interface_name)) {
+        /* return netif with matched name */
+        return netif;
+      }
+    }
+  }
   /* If single netif configuration, fast return. */
   if ((netif_list != NULL) && (netif_list->next == NULL)) {
     if (!netif_is_up(netif_list) || !netif_is_link_up(netif_list)) {
@@ -955,7 +970,7 @@ ip6_output_if_src(struct pbuf *p, const ip6_addr_t *src, const ip6_addr_t *dest,
  */
 err_t
 ip6_output(struct pbuf *p, const ip6_addr_t *src, const ip6_addr_t *dest,
-          u8_t hl, u8_t tc, u8_t nexth)
+          u8_t hl, u8_t tc, u8_t nexth, const char *interface_name)
 {
   struct netif *netif;
   struct ip6_hdr *ip6hdr;
@@ -964,13 +979,13 @@ ip6_output(struct pbuf *p, const ip6_addr_t *src, const ip6_addr_t *dest,
   LWIP_IP_CHECK_PBUF_REF_COUNT_FOR_TX(p);
 
   if (dest != LWIP_IP_HDRINCL) {
-    netif = ip6_route(src, dest);
+    netif = ip6_route(src, dest, interface_name);
   } else {
     /* IP header included in p, read addresses. */
     ip6hdr = (struct ip6_hdr *)p->payload;
     ip6_addr_copy(src_addr, ip6hdr->src);
     ip6_addr_copy(dest_addr, ip6hdr->dest);
-    netif = ip6_route(&src_addr, &dest_addr);
+    netif = ip6_route(&src_addr, &dest_addr, interface_name);
   }
 
   if (netif == NULL) {

--- a/features/lwipstack/lwip/src/core/lwip_dns.c
+++ b/features/lwipstack/lwip/src/core/lwip_dns.c
@@ -305,6 +305,7 @@ static struct dns_table_entry dns_table[DNS_TABLE_SIZE];
 static struct dns_req_entry   dns_requests[DNS_MAX_REQUESTS];
 #endif
 static ip_addr_t              dns_servers[DNS_MAX_SERVERS];
+struct dns_server_interface          *multihoming_dns_servers;
 
 #if LWIP_IPV4
 const ip_addr_t dns_mquery_v4group = DNS_MQUERY_IPV4_GROUP_INIT;
@@ -324,7 +325,7 @@ dns_init(void)
   /* initialize default DNS server address */
   ip_addr_t dnsserver;
   DNS_SERVER_ADDRESS(&dnsserver);
-  dns_setserver(0, &dnsserver);
+  dns_setserver(0, &dnsserver, NULL);
 #endif /* DNS_SERVER_ADDRESS */
 
 #if LWIP_FULL_DNS
@@ -366,14 +367,21 @@ dns_init(void)
  * @param dnsserver IP address of the DNS server to set
  */
 void
-dns_setserver(u8_t numdns, const ip_addr_t *dnsserver)
+dns_setserver(u8_t numdns, const ip_addr_t *dnsserver, struct netif *netif)
 {
-  if (numdns < DNS_MAX_SERVERS) {
-    if (dnsserver != NULL) {
-      dns_servers[numdns] = (*dnsserver);
-    } else {
-      dns_servers[numdns] = *IP_ADDR_ANY;
+
+  if (netif == NULL || netif_check_default(netif)) {
+    if (numdns < DNS_MAX_SERVERS) {
+      if (dnsserver != NULL) {
+        dns_servers[numdns] = (*dnsserver);
+      } else {
+        dns_servers[numdns] = *IP_ADDR_ANY;
+      }
     }
+  } else {
+	    char name[INTERFACE_NAME_SIZE];
+	    sprintf(name, "%c%c%d", netif->name[0], netif->name[1], netif->num);
+        dns_add_interface_server(numdns, name, dnsserver);
   }
 }
 
@@ -386,13 +394,112 @@ dns_setserver(u8_t numdns, const ip_addr_t *dnsserver)
  *         server has not been configured.
  */
 const ip_addr_t*
-dns_getserver(u8_t numdns)
+dns_getserver(u8_t numdns, const char *interface_name)
 {
-  if (numdns < DNS_MAX_SERVERS) {
-    return &dns_servers[numdns];
+  if (interface_name == NULL) {
+    if (numdns < DNS_MAX_SERVERS) {
+      return &dns_servers[numdns];
+    } else {
+      return IP_ADDR_ANY;
+    }
   } else {
+    return dns_get_interface_server(numdns, interface_name);
+  }
+}
+
+/**
+ * @ingroup dns
+ * Initialize one of the DNS servers.
+ *
+ * @param numdns the index of the DNS server to set must be < DNS_MAX_SERVERS
+ * @param dnsserver IP address of the DNS server to set
+ */
+void
+dns_add_interface_server(u8_t numdns, const char *interface_name, const ip_addr_t *dnsserver)
+{
+  struct dns_server_interface *new_interface_server;
+
+  if (numdns < DNS_MAX_SERVERS) {
+    return;
+  }
+
+  if (multihoming_dns_servers != NULL) {
+    // if interface server already exists on the list just update it
+    for (new_interface_server = multihoming_dns_servers; new_interface_server != NULL; new_interface_server = new_interface_server->next) {
+      if (!strcmp(interface_name, new_interface_server->interface_name)) {
+        new_interface_server->dns_servers[numdns] = (*dnsserver);
+        return;
+      }
+    }
+  }
+  // add new dns server to the list tail
+  new_interface_server = mem_malloc(sizeof(struct dns_server_interface));
+  strncpy(new_interface_server->interface_name, interface_name, NETWORK_INTERFACE_NAME_MAX_SIZE);
+  new_interface_server->dns_servers[numdns] = (*dnsserver);
+  new_interface_server->next = NULL;
+
+  if (multihoming_dns_servers == NULL) {
+    multihoming_dns_servers = new_interface_server;
+  } else {
+    struct dns_server_interface *tail;
+    tail = multihoming_dns_servers;
+
+    while (tail->next != NULL) {
+      tail = tail->next;
+    }
+    tail->next = new_interface_server;
+
+  }
+}
+
+void
+dns_remove_interface_servers(const char *interface_name)
+{
+  struct dns_server_interface *temp = multihoming_dns_servers;
+  struct dns_server_interface *prev = NULL;
+
+  if (temp != NULL && !strcmp(interface_name, temp->interface_name)) {
+    multihoming_dns_servers = temp->next;
+    mem_free(temp);
+    return;
+  }
+
+  while (temp != NULL && strcmp(interface_name, temp->interface_name)) {
+    prev = temp;
+    temp = temp->next;
+  }
+
+  if (temp == NULL) {
+    return;
+  }
+
+  prev->next = temp->next;
+  mem_free(temp);
+}
+
+/**
+ * @ingroup dns
+ * Obtain one of the currently configured DNS server.
+ *
+ * @param numdns the index of the DNS server
+ * @return IP address of the indexed DNS server or "ip_addr_any" if the DNS
+ *         server has not been configured.
+ */
+const ip_addr_t *
+dns_get_interface_server(u8_t numdns, const char *interface_name)
+{
+  struct dns_server_interface *interface_server;
+
+  if (numdns < DNS_MAX_SERVERS) {
     return IP_ADDR_ANY;
   }
+
+  for (interface_server = multihoming_dns_servers; interface_server != NULL; interface_server = interface_server->next) {
+    if (!strcmp(interface_name, interface_server->interface_name)) {
+      return &interface_server->dns_servers[numdns];
+    }
+  }
+  return IP_ADDR_ANY;
 }
 
 /**

--- a/features/lwipstack/lwip/src/core/lwip_netif.c
+++ b/features/lwipstack/lwip/src/core/lwip_netif.c
@@ -105,6 +105,7 @@ struct netif *netif_list;
 struct netif *netif_default;
 
 static u8_t netif_num;
+static char netif_name [INTERFACE_NAME_SIZE];
 
 #if LWIP_NUM_NETIF_CLIENT_DATA > 0
 static u8_t netif_client_id;
@@ -467,6 +468,20 @@ netif_remove(struct netif *netif)
 
 /**
  * @ingroup netif
+ * Get a network interface name
+ *
+ * @param  netif
+ * @return name the name of the netif (like netif->name) plus concatenated number
+ * in ascii representation (e.g. 'en0')
+ */
+const char *
+netif_get_name(struct netif *netif)
+{
+  sprintf(netif_name, "%c%c%d", netif->name[0], netif->name[1], netif->num);
+  return netif_name;
+}
+/**
+ * @ingroup netif
  * Find a network interface by searching for its name
  *
  * @param name the name of the netif (like netif->name) plus concatenated number
@@ -617,6 +632,27 @@ netif_set_default(struct netif *netif)
   netif_default = netif;
   LWIP_DEBUGF(NETIF_DEBUG, ("netif: setting default interface %c%c\n",
            netif ? netif->name[0] : '\'', netif ? netif->name[1] : '\''));
+}
+
+/**
+ * @ingroup netif
+ * Checks if  network interface is the default network interface
+ * @param netif the default network interface
+ * @return true if netif is  set to default one
+ * otherwise return false
+ */
+bool
+netif_check_default(struct netif *netif)
+{
+  if (netif == NULL) {
+    return false;
+  }
+  if (netif_default == netif) {
+    return true;
+  } else {
+	return false;
+  }
+
 }
 
 /**

--- a/features/lwipstack/lwip/src/core/lwip_raw.c
+++ b/features/lwipstack/lwip/src/core/lwip_raw.c
@@ -322,9 +322,9 @@ raw_sendto(struct raw_pcb *pcb, struct pbuf *p, const ip_addr_t *ipaddr)
 
   if(IP_IS_ANY_TYPE_VAL(pcb->local_ip)) {
     /* Don't call ip_route() with IP_ANY_TYPE */
-    netif = ip_route(IP46_ADDR_ANY(IP_GET_TYPE(ipaddr)), ipaddr);
+    netif = ip_route(IP46_ADDR_ANY(IP_GET_TYPE(ipaddr)), ipaddr, pcb->interface_name);
   } else {
-    netif = ip_route(&pcb->local_ip, ipaddr);
+    netif = ip_route(&pcb->local_ip, ipaddr, pcb->interface_name);
   }
 
   if (netif == NULL) {

--- a/features/lwipstack/lwip/src/core/lwip_tcp.c
+++ b/features/lwipstack/lwip/src/core/lwip_tcp.c
@@ -273,7 +273,7 @@ tcp_close_shutdown(struct tcp_pcb *pcb, u8_t rst_on_unacked_data)
       /* don't call tcp_abort here: we must not deallocate the pcb since
          that might not be expected when calling tcp_close */
       tcp_rst(pcb->snd_nxt, pcb->rcv_nxt, &pcb->local_ip, &pcb->remote_ip,
-               pcb->local_port, pcb->remote_port);
+               pcb->local_port, pcb->remote_port, pcb->interface_name);
 
       tcp_pcb_purge(pcb);
       TCP_RMV_ACTIVE(pcb);
@@ -512,7 +512,7 @@ tcp_abandon(struct tcp_pcb *pcb, int reset)
     tcp_backlog_accepted(pcb);
     if (send_rst) {
       LWIP_DEBUGF(TCP_RST_DEBUG, ("tcp_abandon: sending RST\n"));
-      tcp_rst(seqno, ackno, &pcb->local_ip, &pcb->remote_ip, local_port, pcb->remote_port);
+      tcp_rst(seqno, ackno, &pcb->local_ip, &pcb->remote_ip, local_port, pcb->remote_port, pcb->interface_name);
     }
     last_state = pcb->state;
     memp_free(MEMP_TCP_PCB, pcb);
@@ -890,7 +890,7 @@ tcp_connect(struct tcp_pcb *pcb, const ip_addr_t *ipaddr, u16_t port,
     /* no local IP address set, yet. */
     struct netif *netif;
     const ip_addr_t *local_ip;
-    ip_route_get_local_ip(&pcb->local_ip, &pcb->remote_ip, netif, local_ip);
+    ip_route_get_local_ip(&pcb->local_ip, &pcb->remote_ip, netif, local_ip, pcb->interface_name);
     if ((netif == NULL) || (local_ip == NULL)) {
       /* Don't even try to send a SYN packet if we have no route
          since that will fail. */
@@ -944,7 +944,7 @@ tcp_connect(struct tcp_pcb *pcb, const ip_addr_t *ipaddr, u16_t port,
      The send MSS is updated when an MSS option is received. */
   pcb->mss = INITIAL_MSS;
 #if TCP_CALCULATE_EFF_SEND_MSS
-  pcb->mss = tcp_eff_send_mss(pcb->mss, &pcb->local_ip, &pcb->remote_ip);
+  pcb->mss = tcp_eff_send_mss(pcb->mss, &pcb->local_ip, &pcb->remote_ip, pcb->interface_name);
 #endif /* TCP_CALCULATE_EFF_SEND_MSS */
   pcb->cwnd = 1;
 #if LWIP_CALLBACK_API
@@ -1162,7 +1162,7 @@ tcp_slowtmr_start:
 
       if (pcb_reset) {
         tcp_rst(pcb->snd_nxt, pcb->rcv_nxt, &pcb->local_ip, &pcb->remote_ip,
-                 pcb->local_port, pcb->remote_port);
+                 pcb->local_port, pcb->remote_port, pcb->interface_name);
       }
 
       err_arg = pcb->callback_arg;
@@ -1911,13 +1911,14 @@ tcp_eff_send_mss_impl(u16_t sendmss, const ip_addr_t *dest
 #if LWIP_IPV6 || LWIP_IPV4_SRC_ROUTING
                      , const ip_addr_t *src
 #endif /* LWIP_IPV6 || LWIP_IPV4_SRC_ROUTING */
+					 , const char *interface_name
                      )
 {
   u16_t mss_s;
   struct netif *outif;
   s16_t mtu;
 
-  outif = ip_route(src, dest);
+  outif = ip_route(src, dest, interface_name);
 #if LWIP_IPV6
 #if LWIP_IPV4
   if (IP_IS_V6(dest))

--- a/features/lwipstack/lwip/src/core/lwip_tcp_in.c
+++ b/features/lwipstack/lwip/src/core/lwip_tcp_in.c
@@ -517,8 +517,9 @@ aborted:
     if (!(TCPH_FLAGS(tcphdr) & TCP_RST)) {
       TCP_STATS_INC(tcp.proterr);
       TCP_STATS_INC(tcp.drop);
+
       tcp_rst(ackno, seqno + tcplen, ip_current_dest_addr(),
-        ip_current_src_addr(), tcphdr->dest, tcphdr->src);
+        ip_current_src_addr(), tcphdr->dest, tcphdr->src, netif_get_name(inp));
     }
     pbuf_free(p);
   }
@@ -560,7 +561,7 @@ tcp_listen_input(struct tcp_pcb_listen *pcb)
        RST. */
     LWIP_DEBUGF(TCP_RST_DEBUG, ("tcp_listen_input: ACK in LISTEN, sending reset\n"));
     tcp_rst(ackno, seqno + tcplen, ip_current_dest_addr(),
-      ip_current_src_addr(), tcphdr->dest, tcphdr->src);
+      ip_current_src_addr(), tcphdr->dest, tcphdr->src, pcb->interface_name);
   } else if (flags & TCP_SYN) {
     LWIP_DEBUGF(TCP_DEBUG, ("TCP connection request %"U16_F" -> %"U16_F".\n", tcphdr->src, tcphdr->dest));
 #if TCP_LISTEN_BACKLOG
@@ -615,7 +616,7 @@ tcp_listen_input(struct tcp_pcb_listen *pcb)
     npcb->snd_wnd_max = npcb->snd_wnd;
 
 #if TCP_CALCULATE_EFF_SEND_MSS
-    npcb->mss = tcp_eff_send_mss(npcb->mss, &npcb->local_ip, &npcb->remote_ip);
+    npcb->mss = tcp_eff_send_mss(npcb->mss, &npcb->local_ip, &npcb->remote_ip, npcb->interface_name);
 #endif /* TCP_CALCULATE_EFF_SEND_MSS */
 
     MIB2_STATS_INC(mib2.tcppassiveopens);
@@ -658,7 +659,7 @@ tcp_timewait_input(struct tcp_pcb *pcb)
     if (TCP_SEQ_BETWEEN(seqno, pcb->rcv_nxt, pcb->rcv_nxt + pcb->rcv_wnd)) {
       /* If the SYN is in the window it is an error, send a reset */
       tcp_rst(ackno, seqno + tcplen, ip_current_dest_addr(),
-        ip_current_src_addr(), tcphdr->dest, tcphdr->src);
+        ip_current_src_addr(), tcphdr->dest, tcphdr->src, pcb->interface_name);
       return;
     }
   } else if (flags & TCP_FIN) {
@@ -765,7 +766,7 @@ tcp_process(struct tcp_pcb *pcb)
       pcb->state = ESTABLISHED;
 
 #if TCP_CALCULATE_EFF_SEND_MSS
-      pcb->mss = tcp_eff_send_mss(pcb->mss, &pcb->local_ip, &pcb->remote_ip);
+      pcb->mss = tcp_eff_send_mss(pcb->mss, &pcb->local_ip, &pcb->remote_ip, pcb->interface_name);
 #endif /* TCP_CALCULATE_EFF_SEND_MSS */
 
       pcb->cwnd = LWIP_TCP_CALC_INITIAL_CWND(pcb->mss);
@@ -808,7 +809,7 @@ tcp_process(struct tcp_pcb *pcb)
     else if (flags & TCP_ACK) {
       /* send a RST to bring the other side in a non-synchronized state. */
       tcp_rst(ackno, seqno + tcplen, ip_current_dest_addr(),
-        ip_current_src_addr(), tcphdr->dest, tcphdr->src);
+        ip_current_src_addr(), tcphdr->dest, tcphdr->src, pcb->interface_name);
       /* Resend SYN immediately (don't wait for rto timeout) to establish
         connection faster, but do not send more SYNs than we otherwise would
         have, or we might get caught in a loop on loopback interfaces. */
@@ -869,7 +870,7 @@ tcp_process(struct tcp_pcb *pcb)
       } else {
         /* incorrect ACK number, send RST */
         tcp_rst(ackno, seqno + tcplen, ip_current_dest_addr(),
-          ip_current_src_addr(), tcphdr->dest, tcphdr->src);
+          ip_current_src_addr(), tcphdr->dest, tcphdr->src, pcb->interface_name);
       }
     } else if ((flags & TCP_SYN) && (seqno == pcb->rcv_nxt - 1)) {
       /* Looks like another copy of the SYN - retransmit our SYN-ACK */

--- a/features/lwipstack/lwip/src/core/lwip_tcp_out.c
+++ b/features/lwipstack/lwip/src/core/lwip_tcp_out.c
@@ -953,7 +953,7 @@ tcp_send_empty_ack(struct tcp_pcb *pcb)
   }
 #endif
 
-  netif = ip_route(&pcb->local_ip, &pcb->remote_ip);
+  netif = ip_route(&pcb->local_ip, &pcb->remote_ip, pcb->interface_name);
   if (netif == NULL) {
     err = ERR_RTE;
   } else {
@@ -1034,7 +1034,7 @@ tcp_output(struct tcp_pcb *pcb)
     for (; useg->next != NULL; useg = useg->next);
   }
 
-  netif = ip_route(&pcb->local_ip, &pcb->remote_ip);
+  netif = ip_route(&pcb->local_ip, &pcb->remote_ip, pcb->interface_name);
   if (netif == NULL) {
     return ERR_RTE;
   }
@@ -1224,7 +1224,7 @@ tcp_output_segment(struct tcp_seg *seg, struct tcp_pcb *pcb, struct netif *netif
   if (seg->flags & TF_SEG_OPTS_MSS) {
     u16_t mss;
 #if TCP_CALCULATE_EFF_SEND_MSS
-    mss = tcp_eff_send_mss(TCP_MSS, &pcb->local_ip, &pcb->remote_ip);
+    mss = tcp_eff_send_mss(TCP_MSS, &pcb->local_ip, &pcb->remote_ip, pcb->interface_name);
 #else /* TCP_CALCULATE_EFF_SEND_MSS */
     mss = TCP_MSS;
 #endif /* TCP_CALCULATE_EFF_SEND_MSS */
@@ -1343,7 +1343,7 @@ tcp_output_segment(struct tcp_seg *seg, struct tcp_pcb *pcb, struct netif *netif
 void
 tcp_rst(u32_t seqno, u32_t ackno,
   const ip_addr_t *local_ip, const ip_addr_t *remote_ip,
-  u16_t local_port, u16_t remote_port)
+  u16_t local_port, u16_t remote_port, const char *interface_name)
 {
   struct pbuf *p;
   struct tcp_hdr *tcphdr;
@@ -1373,7 +1373,7 @@ tcp_rst(u32_t seqno, u32_t ackno,
   TCP_STATS_INC(tcp.xmit);
   MIB2_STATS_INC(mib2.tcpoutrsts);
 
-  netif = ip_route(local_ip, remote_ip);
+  netif = ip_route(local_ip, remote_ip, interface_name);
   if (netif != NULL) {
 #if CHECKSUM_GEN_TCP
     IF__NETIF_CHECKSUM_ENABLED(netif, NETIF_CHECKSUM_GEN_TCP) {
@@ -1548,7 +1548,7 @@ tcp_keepalive(struct tcp_pcb *pcb)
                 ("tcp_keepalive: could not allocate memory for pbuf\n"));
     return ERR_MEM;
   }
-  netif = ip_route(&pcb->local_ip, &pcb->remote_ip);
+  netif = ip_route(&pcb->local_ip, &pcb->remote_ip, pcb->interface_name);
   if (netif == NULL) {
     err = ERR_RTE;
   } else {
@@ -1642,7 +1642,7 @@ tcp_zero_window_probe(struct tcp_pcb *pcb)
     pcb->snd_nxt = snd_nxt;
   }
 
-  netif = ip_route(&pcb->local_ip, &pcb->remote_ip);
+  netif = ip_route(&pcb->local_ip, &pcb->remote_ip, pcb->interface_name);
   if (netif == NULL) {
     err = ERR_RTE;
   } else {

--- a/features/lwipstack/lwip/src/core/lwip_udp.c
+++ b/features/lwipstack/lwip/src/core/lwip_udp.c
@@ -548,9 +548,9 @@ udp_sendto_chksum(struct udp_pcb *pcb, struct pbuf *p, const ip_addr_t *dst_ip,
   /* find the outgoing network interface for this packet */
   if(IP_IS_ANY_TYPE_VAL(pcb->local_ip)) {
     /* Don't call ip_route() with IP_ANY_TYPE */
-    netif = ip_route(IP46_ADDR_ANY(IP_GET_TYPE(dst_ip_route)), dst_ip_route);
+    netif = ip_route(IP46_ADDR_ANY(IP_GET_TYPE(dst_ip_route)), dst_ip_route, pcb->interface_name);
   } else {
-    netif = ip_route(&pcb->local_ip, dst_ip_route);
+    netif = ip_route(&pcb->local_ip, dst_ip_route, pcb->interface_name);
   }
 
   /* no outgoing network interface could be found? */

--- a/features/lwipstack/lwip/src/include/lwip/dns.h
+++ b/features/lwipstack/lwip/src/include/lwip/dns.h
@@ -49,6 +49,12 @@
 extern "C" {
 #endif
 
+struct dns_server_interface {
+    char interface_name [NETWORK_INTERFACE_NAME_MAX_SIZE];
+    ip_addr_t              dns_servers[DNS_MAX_SERVERS];
+    struct dns_server_interface *next;
+};
+
 /** DNS timer period */
 #define DNS_TMR_INTERVAL          1000
 
@@ -103,8 +109,11 @@ typedef void (*dns_found_callback)(const char *name, const ip_addr_t *ipaddr, vo
 
 void             dns_init(void);
 void             dns_tmr(void);
-void             dns_setserver(u8_t numdns, const ip_addr_t *dnsserver);
-const ip_addr_t* dns_getserver(u8_t numdns);
+void             dns_setserver(u8_t numdns, const ip_addr_t *dnsserver, struct netif *netif);
+const ip_addr_t* dns_getserver(u8_t numdns, const char *interface_name);
+void dns_add_interface_server(u8_t numdns, const char *interface_name, const ip_addr_t *dnsserver);
+void dns_remove_interface_servers(const char *interface_name);
+const ip_addr_t* dns_get_interface_server(u8_t numdns, const char *interface_name);
 err_t            dns_gethostbyname(const char *hostname, ip_addr_t *addr,
                                    dns_found_callback found, void *callback_arg);
 err_t            dns_gethostbyname_addrtype(const char *hostname, ip_addr_t *addr,

--- a/features/lwipstack/lwip/src/include/lwip/ip.h
+++ b/features/lwipstack/lwip/src/include/lwip/ip.h
@@ -82,7 +82,9 @@ extern "C" {
    /* Type Of Service */ \
   u8_t tos;              \
   /* Time To Live */     \
-  u8_t ttl               \
+  u8_t ttl;               \
+  /* interface_name */  \
+  const char* interface_name 	 \
   /* link layer address resolution hint */ \
   IP_PCB_ADDRHINT
 
@@ -252,10 +254,10 @@ extern struct ip_globals ip_data;
  * @ingroup ip
  * Get netif for address combination. See \ref ip6_route and \ref ip4_route
  */
-#define ip_route(src, dest) \
+#define ip_route(src, dest, interface_name) \
         (IP_IS_V6(dest) ? \
-        ip6_route(ip_2_ip6(src), ip_2_ip6(dest)) : \
-        ip4_route_src(ip_2_ip4(dest), ip_2_ip4(src)))
+        ip6_route(ip_2_ip6(src), ip_2_ip6(dest), interface_name) : \
+        ip4_route_src(ip_2_ip4(dest), ip_2_ip4(src), interface_name))
 /**
  * @ingroup ip
  * Get netif for IP.
@@ -277,8 +279,8 @@ err_t ip_input(struct pbuf *p, struct netif *inp);
         ip4_output_if_src(p, src, dest, ttl, tos, proto, netif)
 #define ip_output_hinted(p, src, dest, ttl, tos, proto, addr_hint) \
         ip4_output_hinted(p, src, dest, ttl, tos, proto, addr_hint)
-#define ip_route(src, dest) \
-        ip4_route_src(dest, src)
+#define ip_route(src, dest, interface_name) \
+        ip4_route_src(dest, src, interface_name)
 #define ip_netif_get_local_ip(netif, dest) \
         ip4_netif_get_local_ip(netif)
 #define ip_debug_print(is_ipv6, p) ip4_debug_print(p)
@@ -295,8 +297,8 @@ err_t ip_input(struct pbuf *p, struct netif *inp);
         ip6_output_if_src(p, src, dest, ttl, tos, proto, netif)
 #define ip_output_hinted(p, src, dest, ttl, tos, proto, addr_hint) \
         ip6_output_hinted(p, src, dest, ttl, tos, proto, addr_hint)
-#define ip_route(src, dest) \
-        ip6_route(src, dest)
+#define ip_route(src, dest, interface_name) \
+        ip6_route(src, dest, interface_name)
 #define ip_netif_get_local_ip(netif, dest) \
         ip6_netif_get_local_ip(netif, dest)
 #define ip_debug_print(is_ipv6, p) ip6_debug_print(p)
@@ -305,8 +307,8 @@ err_t ip_input(struct pbuf *p, struct netif *inp);
 
 #endif /* LWIP_IPV6 */
 
-#define ip_route_get_local_ip(src, dest, netif, ipaddr) do { \
-  (netif) = ip_route(src, dest); \
+#define ip_route_get_local_ip(src, dest, netif, ipaddr, interface_name) do { \
+  (netif) = ip_route(src, dest, interface_name); \
   (ipaddr) = ip_netif_get_local_ip(netif, dest); \
 }while(0)
 

--- a/features/lwipstack/lwip/src/include/lwip/ip4.h
+++ b/features/lwipstack/lwip/src/include/lwip/ip4.h
@@ -62,15 +62,15 @@ extern "C" {
 #define IP_OPTIONS_SEND   (LWIP_IPV4 && LWIP_IGMP)
 
 #define ip_init() /* Compatibility define, no init needed. */
-struct netif *ip4_route(const ip4_addr_t *dest);
+struct netif *ip4_route(const ip4_addr_t *dest, const char *interface_name);
 #if LWIP_IPV4_SRC_ROUTING
-struct netif *ip4_route_src(const ip4_addr_t *dest, const ip4_addr_t *src);
+struct netif *ip4_route_src(const ip4_addr_t *dest, const ip4_addr_t *src, const char *interface_name);
 #else /* LWIP_IPV4_SRC_ROUTING */
-#define ip4_route_src(dest, src) ip4_route(dest)
+#define ip4_route_src(dest, src, interface_name) ip4_route(dest, interface_name)
 #endif /* LWIP_IPV4_SRC_ROUTING */
 err_t ip4_input(struct pbuf *p, struct netif *inp);
 err_t ip4_output(struct pbuf *p, const ip4_addr_t *src, const ip4_addr_t *dest,
-       u8_t ttl, u8_t tos, u8_t proto);
+       u8_t ttl, u8_t tos, u8_t proto, const char *interface_name);
 err_t ip4_output_if(struct pbuf *p, const ip4_addr_t *src, const ip4_addr_t *dest,
        u8_t ttl, u8_t tos, u8_t proto, struct netif *netif);
 err_t ip4_output_if_src(struct pbuf *p, const ip4_addr_t *src, const ip4_addr_t *dest,

--- a/features/lwipstack/lwip/src/include/lwip/ip6.h
+++ b/features/lwipstack/lwip/src/include/lwip/ip6.h
@@ -57,11 +57,11 @@
 extern "C" {
 #endif
 
-struct netif *ip6_route(const ip6_addr_t *src, const ip6_addr_t *dest);
+struct netif *ip6_route(const ip6_addr_t *src, const ip6_addr_t *dest, const char *interface_name);
 const ip_addr_t *ip6_select_source_address(struct netif *netif, const ip6_addr_t * dest);
 err_t         ip6_input(struct pbuf *p, struct netif *inp);
 err_t         ip6_output(struct pbuf *p, const ip6_addr_t *src, const ip6_addr_t *dest,
-                         u8_t hl, u8_t tc, u8_t nexth);
+                         u8_t hl, u8_t tc, u8_t nexth, const char *interface_name);
 err_t         ip6_output_if(struct pbuf *p, const ip6_addr_t *src, const ip6_addr_t *dest,
                             u8_t hl, u8_t tc, u8_t nexth, struct netif *netif);
 err_t         ip6_output_if_src(struct pbuf *p, const ip6_addr_t *src, const ip6_addr_t *dest,

--- a/features/lwipstack/lwip/src/include/lwip/netif.h
+++ b/features/lwipstack/lwip/src/include/lwip/netif.h
@@ -37,6 +37,7 @@
 #ifndef LWIP_HDR_NETIF_H
 #define LWIP_HDR_NETIF_H
 
+#include <stdbool.h>
 #include "lwip/opt.h"
 
 #define ENABLE_LOOPBACK (LWIP_NETIF_LOOPBACK || LWIP_HAVE_LOOPIF)
@@ -135,6 +136,8 @@ enum lwip_internal_netif_client_data_index
 #define NETIF_CHECKSUM_ENABLE_ALL   0xFFFF
 #define NETIF_CHECKSUM_DISABLE_ALL  0x0000
 #endif /* LWIP_CHECKSUM_CTRL_PER_NETIF */
+
+#define INTERFACE_NAME_SIZE    6
 
 struct netif;
 
@@ -380,7 +383,15 @@ void netif_remove(struct netif * netif);
    structure. */
 struct netif *netif_find(const char *name);
 
+/* Returns a network interface  name in the form
+   "et0", where the first two letters are the "name" field in the
+   netif structure, and the digit is in the num field in the same
+   structure. */
+const char *netif_get_name(struct netif *netif);
+
 void netif_set_default(struct netif *netif);
+bool netif_check_default(struct netif *netif);
+
 
 #if LWIP_IPV4
 void netif_set_ipaddr(struct netif *netif, const ip4_addr_t *ipaddr);

--- a/features/lwipstack/lwip/src/include/lwip/pbuf.h
+++ b/features/lwipstack/lwip/src/include/lwip/pbuf.h
@@ -170,6 +170,7 @@ struct pbuf {
    * the stack itself, or pbuf->next pointers from a chain.
    */
   u16_t ref;
+  struct netif *netif;
 };
 
 

--- a/features/lwipstack/lwip/src/include/lwip/priv/tcp_priv.h
+++ b/features/lwipstack/lwip/src/include/lwip/priv/tcp_priv.h
@@ -453,7 +453,7 @@ void tcp_rexmit_seg(struct tcp_pcb *pcb, struct tcp_seg *seg);
 
 void tcp_rst(u32_t seqno, u32_t ackno,
        const ip_addr_t *local_ip, const ip_addr_t *remote_ip,
-       u16_t local_port, u16_t remote_port);
+       u16_t local_port, u16_t remote_port, const char *interface_name);
 
 u32_t tcp_next_iss(struct tcp_pcb *pcb);
 
@@ -466,11 +466,12 @@ u16_t tcp_eff_send_mss_impl(u16_t sendmss, const ip_addr_t *dest
 #if LWIP_IPV6 || LWIP_IPV4_SRC_ROUTING
                            , const ip_addr_t *src
 #endif /* LWIP_IPV6 || LWIP_IPV4_SRC_ROUTING */
+						   , const char *interface_name
                            );
 #if LWIP_IPV6 || LWIP_IPV4_SRC_ROUTING
-#define tcp_eff_send_mss(sendmss, src, dest) tcp_eff_send_mss_impl(sendmss, dest, src)
+#define tcp_eff_send_mss(sendmss, src, dest, interface_name) tcp_eff_send_mss_impl(sendmss, dest, src, interface_name)
 #else /* LWIP_IPV6 || LWIP_IPV4_SRC_ROUTING */
-#define tcp_eff_send_mss(sendmss, src, dest) tcp_eff_send_mss_impl(sendmss, dest)
+#define tcp_eff_send_mss(sendmss, src, dest, interface_name) tcp_eff_send_mss_impl(sendmss, dest, interface_name)
 #endif /* LWIP_IPV6 || LWIP_IPV4_SRC_ROUTING */
 #endif /* TCP_CALCULATE_EFF_SEND_MSS */
 

--- a/features/lwipstack/lwipopts.h
+++ b/features/lwipstack/lwipopts.h
@@ -332,6 +332,8 @@
 #endif // MBED_CONF_LWIP_ETHERNET_ENABLED
 
 #define LWIP_L3IP   				0
+//Maximum size of network interface name
+#define NETWORK_INTERFACE_NAME_MAX_SIZE 4
 // Note generic macro name used rather than MBED_CONF_LWIP_PPP_ENABLED
 // to allow users like PPPCellularInterface to detect that nsapi_ppp.h is available.
 #if NSAPI_PPP_AVAILABLE

--- a/features/nanostack/mbed-mesh-api/mbed-mesh-api/MeshInterfaceNanostack.h
+++ b/features/nanostack/mbed-mesh-api/mbed-mesh-api/MeshInterfaceNanostack.h
@@ -25,7 +25,7 @@
 
 class Nanostack::Interface : public OnboardNetworkStack::Interface, private mbed::NonCopyable<Nanostack::Interface> {
 public:
-    virtual char *get_ip_address(char *buf, nsapi_size_t buflen);
+    virtual char *get_ip_address(char *buf, nsapi_size_t buflen, const char *interface_name);
     virtual char *get_mac_address(char *buf, nsapi_size_t buflen);
     virtual char *get_netmask(char *buf, nsapi_size_t buflen);
     virtual char *get_gateway(char *buf, nsapi_size_t buflen);

--- a/features/nanostack/mbed-mesh-api/source/MeshInterfaceNanostack.cpp
+++ b/features/nanostack/mbed-mesh-api/source/MeshInterfaceNanostack.cpp
@@ -22,7 +22,7 @@
 #include "thread_management_if.h"
 #include "ip6string.h"
 
-char *Nanostack::Interface::get_ip_address(char *buf, nsapi_size_t buflen)
+char *Nanostack::Interface::get_ip_address(char *buf, nsapi_size_t buflen, const char *interface_name)
 {
     NanostackLockGuard lock;
     uint8_t binary_ipv6[16];
@@ -172,7 +172,7 @@ Nanostack *InterfaceNanostack::get_stack()
 
 const char *InterfaceNanostack::get_ip_address()
 {
-    if (_interface->get_ip_address(ip_addr_str, sizeof(ip_addr_str))) {
+    if (_interface->get_ip_address(ip_addr_str, sizeof(ip_addr_str),NULL)) {
         return ip_addr_str;
     }
     return NULL;

--- a/features/netsocket/DNS.h
+++ b/features/netsocket/DNS.h
@@ -37,6 +37,23 @@ public:
     virtual nsapi_error_t gethostbyname(const char *host,
                                         SocketAddress *address, nsapi_version_t version = NSAPI_UNSPEC) = 0;
 
+    /** Translate a hostname to an IP address with specific version using network interface name.
+     *
+     *  The hostname may be either a domain name or an IP address. If the
+     *  hostname is an IP address, no network transactions will be performed.
+     *
+     *  If no stack-specific DNS resolution is provided, the hostname
+     *  will be resolve using a UDP socket on the stack.
+     *
+     *  @param host     Hostname to resolve.
+     *  @param address  Pointer to a SocketAddress to store the result.
+     *  @param version  IP version of address to resolve, NSAPI_UNSPEC indicates
+     *  @param interface_name  Network interface name
+     *                  version is chosen by the stack (defaults to NSAPI_UNSPEC).
+     *  @return         NSAPI_ERROR_OK on success, negative error code on failure.
+     */
+    virtual nsapi_error_t gethostbyname(const char *host,
+                                        SocketAddress *address, const char *interface_name, nsapi_version_t version = NSAPI_UNSPEC) = 0;
     /** Hostname translation callback for gethostbyname_async.
      *
      *  The callback is called after DNS resolution completes, or a failure occurs.
@@ -77,6 +94,32 @@ public:
     virtual nsapi_value_or_error_t gethostbyname_async(const char *host, hostbyname_cb_t callback,
                                                        nsapi_version_t version = NSAPI_UNSPEC) = 0;
 
+    /** Translate a hostname to an IP address (asynchronous) using network interface name.
+     *
+     *  The hostname may be either a domain name or an IP address. If the
+     *  hostname is an IP address, no network transactions will be performed.
+     *
+     *  If no stack-specific DNS resolution is provided, the hostname
+     *  will be resolved using a UDP socket on the stack.
+     *
+     *  The call is non-blocking. The result of the DNS operation is returned by the callback.
+     *  If this function returns failure, the callback will not be called. If it is successful,
+     *  (the IP address was found from the DNS cache), the callback will be called
+     *  before the function returns.
+     *
+     *  @param host     Hostname to resolve.
+     *  @param callback Callback that is called to return the result.
+     *  @param interface_name  Network interface name
+     *  @param version  IP version of address to resolve. NSAPI_UNSPEC indicates that the
+     *                  version is chosen by the stack (defaults to NSAPI_UNSPEC).
+     *  @return         NSAPI_ERROR_OK on immediate success,
+     *                  negative error code on immediate failure or
+     *                  a positive unique ID that represents the hostname translation operation
+     *                  and can be passed to cancel.
+     */
+    virtual nsapi_value_or_error_t gethostbyname_async(const char *host, hostbyname_cb_t callback, const char *interface_name,
+                                                       nsapi_version_t version = NSAPI_UNSPEC) = 0;
+
     /** Cancel asynchronous hostname translation.
      *
      *  When translation is canceled, callback is not called.
@@ -89,9 +132,10 @@ public:
     /** Add a domain name server to list of servers to query.
      *
      *  @param address  DNS server host address.
+     *  @param interface_name  Network interface name
      *  @return         NSAPI_ERROR_OK on success, negative error code on failure.
      */
-    virtual nsapi_error_t add_dns_server(const SocketAddress &address) = 0;
+    virtual nsapi_error_t add_dns_server(const SocketAddress &address, const char *interface_name = NULL) = 0;
 };
 
 #endif

--- a/features/netsocket/EMACInterface.cpp
+++ b/features/netsocket/EMACInterface.cpp
@@ -85,9 +85,9 @@ const char *EMACInterface::get_mac_address()
     return NULL;
 }
 
-const char *EMACInterface::get_ip_address()
+const char *EMACInterface::get_ip_address(const char *interface_name)
 {
-    if (_interface && _interface->get_ip_address(_ip_address, sizeof(_ip_address))) {
+    if (_interface && _interface->get_ip_address(_ip_address, sizeof(_ip_address),interface_name)) {
         return _ip_address;
     }
 

--- a/features/netsocket/EMACInterface.h
+++ b/features/netsocket/EMACInterface.h
@@ -101,7 +101,7 @@ public:
      *  @return         Null-terminated representation of the local IP address
      *                  or null if no IP address has been received
      */
-    virtual const char *get_ip_address();
+    virtual const char *get_ip_address(const char *interface_name);
 
     /** Get the local network mask
      *

--- a/features/netsocket/InternetSocket.cpp
+++ b/features/netsocket/InternetSocket.cpp
@@ -53,7 +53,7 @@ nsapi_error_t InternetSocket::open(NetworkStack *stack)
     _socket = socket;
     _event = callback(this, &InternetSocket::event);
     _stack->socket_attach(_socket, Callback<void()>::thunk, &_event);
-
+    _interface_name[0] = '\0';
     _lock.unlock();
     return NSAPI_ERROR_OK;
 }
@@ -85,7 +85,7 @@ nsapi_error_t InternetSocket::close()
         _event_flag.wait_any(FINISHED_FLAG, osWaitForever);
         _lock.lock();
     }
-
+    _interface_name[0] = '\0';
     _lock.unlock();
 
     // When allocated by accept() call, will destroy itself on close();
@@ -174,6 +174,9 @@ nsapi_error_t InternetSocket::setsockopt(int level, int optname, const void *opt
         ret = NSAPI_ERROR_NO_SOCKET;
     } else {
         ret = _stack->setsockopt(_socket, level, optname, optval, optlen);
+        if (optname == NSAPI_BIND_TO_DEVICE && level == NSAPI_SOCKET) {
+            strncpy(_interface_name, static_cast<const char *>(optval), optlen);
+        }
     }
 
     _lock.unlock();

--- a/features/netsocket/InternetSocket.h
+++ b/features/netsocket/InternetSocket.h
@@ -157,7 +157,7 @@ protected:
     virtual nsapi_protocol_t get_proto() = 0;
     virtual void event();
     int modify_multicast_group(const SocketAddress &address, nsapi_socket_option_t socketopt);
-
+    char _interface_name[NSAPI_INTERFACE_NAME_MAX_SIZE];
     NetworkStack *_stack;
     nsapi_socket_t _socket;
     uint32_t _timeout;

--- a/features/netsocket/L3IPInterface.cpp
+++ b/features/netsocket/L3IPInterface.cpp
@@ -83,9 +83,9 @@ nsapi_error_t L3IPInterface::disconnect()
     return NSAPI_ERROR_NO_CONNECTION;
 }
 
-const char *L3IPInterface::get_ip_address()
+const char *L3IPInterface::get_ip_address(const char *interface_name)
 {
-    if (_interface && _interface->get_ip_address(_ip_address, sizeof(_ip_address))) {
+    if (_interface && _interface->get_ip_address(_ip_address, sizeof(_ip_address), interface_name)) {
         return _ip_address;
     }
 

--- a/features/netsocket/L3IPInterface.h
+++ b/features/netsocket/L3IPInterface.h
@@ -87,7 +87,7 @@ public:
      *  @return         Null-terminated representation of the local IP address
      *                  or null if no IP address has been recieved
      */
-    virtual const char *get_ip_address();
+    virtual const char *get_ip_address(const char *interface_name);
 
     /** Get the local network mask
      *

--- a/features/netsocket/NetworkInterface.cpp
+++ b/features/netsocket/NetworkInterface.cpp
@@ -25,7 +25,7 @@ const char *NetworkInterface::get_mac_address()
     return 0;
 }
 
-const char *NetworkInterface::get_ip_address()
+const char *NetworkInterface::get_ip_address(const char *interface_name)
 {
     return 0;
 }
@@ -60,9 +60,20 @@ nsapi_error_t NetworkInterface::gethostbyname(const char *name, SocketAddress *a
     return get_stack()->gethostbyname(name, address, version);
 }
 
+nsapi_error_t NetworkInterface::gethostbyname(const char *name, SocketAddress *address, const char *interface_name, nsapi_version_t version)
+{
+    return get_stack()->gethostbyname(name, address, interface_name, version);
+}
+
+
 nsapi_value_or_error_t NetworkInterface::gethostbyname_async(const char *host, hostbyname_cb_t callback, nsapi_version_t version)
 {
     return get_stack()->gethostbyname_async(host, callback, version);
+}
+
+nsapi_value_or_error_t NetworkInterface::gethostbyname_async(const char *host, hostbyname_cb_t callback, const char *interface_name, nsapi_version_t version)
+{
+    return get_stack()->gethostbyname_async(host, callback, interface_name, version);
 }
 
 nsapi_error_t NetworkInterface::gethostbyname_async_cancel(int id)
@@ -70,9 +81,9 @@ nsapi_error_t NetworkInterface::gethostbyname_async_cancel(int id)
     return get_stack()->gethostbyname_async_cancel(id);
 }
 
-nsapi_error_t NetworkInterface::add_dns_server(const SocketAddress &address)
+nsapi_error_t NetworkInterface::add_dns_server(const SocketAddress &address, const char *interface_name)
 {
-    return get_stack()->add_dns_server(address);
+    return get_stack()->add_dns_server(address, interface_name);
 }
 
 void NetworkInterface::attach(mbed::Callback<void(nsapi_event_t, intptr_t)> status_cb)

--- a/features/netsocket/NetworkInterface.h
+++ b/features/netsocket/NetworkInterface.h
@@ -96,7 +96,7 @@ public:
      *  @return         Null-terminated representation of the local IP address
      *                  or null if no IP address has been received.
      */
-    virtual const char *get_ip_address();
+    virtual const char *get_ip_address(const char *interface_name = NULL);
 
     /** Get the local network mask.
      *
@@ -176,6 +176,24 @@ public:
     virtual nsapi_error_t gethostbyname(const char *host,
                                         SocketAddress *address, nsapi_version_t version = NSAPI_UNSPEC);
 
+    /** Translate a hostname to an IP address with specific version using network interface name.
+     *
+     *  The hostname may be either a domain name or an IP address. If the
+     *  hostname is an IP address, no network transactions will be performed.
+     *
+     *  If no stack-specific DNS resolution is provided, the hostname
+     *  will be resolve using a UDP socket on the stack.
+     *
+     *  @param host     Hostname to resolve.
+     *  @param address  Pointer to a SocketAddress to store the result.
+     *  @param version  IP version of address to resolve, NSAPI_UNSPEC indicates
+     *  @param interface_name  Network interface name
+     *                  version is chosen by the stack (defaults to NSAPI_UNSPEC).
+     *  @return         NSAPI_ERROR_OK on success, negative error code on failure.
+     */
+    virtual nsapi_error_t gethostbyname(const char *host,
+                                        SocketAddress *address, const char *interface_name, nsapi_version_t version = NSAPI_UNSPEC);
+
     /** Hostname translation callback (for use with gethostbyname_async()).
      *
      *  Callback will be called after DNS resolution completes or a failure occurs.
@@ -216,6 +234,32 @@ public:
     virtual nsapi_value_or_error_t gethostbyname_async(const char *host, hostbyname_cb_t callback,
                                                        nsapi_version_t version = NSAPI_UNSPEC);
 
+    /** Translate a hostname to an IP address (asynchronous) using network interface name.
+     *
+     *  The hostname may be either a domain name or a dotted IP address. If the
+     *  hostname is an IP address, no network transactions will be performed.
+     *
+     *  If no stack-specific DNS resolution is provided, the hostname
+     *  will be resolve using a UDP socket on the stack.
+     *
+     *  Call is non-blocking. Result of the DNS operation is returned by the callback.
+     *  If this function returns failure, callback will not be called. In case result
+     *  is success (IP address was found from DNS cache), callback will be called
+     *  before function returns.
+     *
+     *  @param host     Hostname to resolve.
+     *  @param callback Callback that is called for result.
+     *  @param version  IP version of address to resolve, NSAPI_UNSPEC indicates
+     *  @param interface_name  Network interface_name
+     *                  version is chosen by the stack (defaults to NSAPI_UNSPEC).
+     *  @return         0 on immediate success,
+     *                  negative error code on immediate failure or
+     *                  a positive unique id that represents the hostname translation operation
+     *                  and can be passed to cancel.
+     */
+    virtual nsapi_value_or_error_t gethostbyname_async(const char *host, hostbyname_cb_t callback, const char *interface_name,
+                                                       nsapi_version_t version = NSAPI_UNSPEC);
+
     /** Cancel asynchronous hostname translation.
      *
      *  When translation is cancelled, callback will not be called.
@@ -231,7 +275,7 @@ public:
      *  @param address  Address for the dns host.
      *  @return         NSAPI_ERROR_OK on success, negative error code on failure.
      */
-    virtual nsapi_error_t add_dns_server(const SocketAddress &address);
+    virtual nsapi_error_t add_dns_server(const SocketAddress &address, const char *interface_name);
 
     /** Register callback for status reporting.
      *

--- a/features/netsocket/NetworkStack.h
+++ b/features/netsocket/NetworkStack.h
@@ -40,10 +40,11 @@ public:
 
     /** Get the local IP address
      *
+     *  @param          interface_name  Network interface_name
      *  @return         Null-terminated representation of the local IP address
      *                  or null if not yet connected
      */
-    virtual const char *get_ip_address();
+    virtual const char *get_ip_address(const char *interface_name = NULL);
 
     /** Translates a hostname to an IP address with specific version
      *
@@ -61,6 +62,24 @@ public:
      */
     virtual nsapi_error_t gethostbyname(const char *host,
                                         SocketAddress *address, nsapi_version_t version = NSAPI_UNSPEC);
+
+    /** Translates a hostname to an IP address with specific version using network interface name.
+     *
+     *  The hostname may be either a domain name or an IP address. If the
+     *  hostname is an IP address, no network transactions will be performed.
+     *
+     *  If no stack-specific DNS resolution is provided, the hostname
+     *  will be resolve using a UDP socket on the stack.
+     *
+     *  @param host     Hostname to resolve
+     *  @param address  Pointer to a SocketAddress to store the result.
+     *  @param version  IP version of address to resolve, NSAPI_UNSPEC indicates
+     *  @param interface_name  Network interface_name
+     *                  version is chosen by the stack (defaults to NSAPI_UNSPEC)
+     *  @return         NSAPI_ERROR_OK on success, negative error code on failure
+     */
+    virtual nsapi_error_t gethostbyname(const char *host,
+                                        SocketAddress *address, const char *interface_name, nsapi_version_t version = NSAPI_UNSPEC);
 
     /** Hostname translation callback (asynchronous)
      *
@@ -102,6 +121,32 @@ public:
     virtual nsapi_value_or_error_t gethostbyname_async(const char *host, hostbyname_cb_t callback,
                                                        nsapi_version_t version = NSAPI_UNSPEC);
 
+    /** Translates a hostname to an IP address (asynchronous) using network interface name
+     *
+     *  The hostname may be either a domain name or an IP address. If the
+     *  hostname is an IP address, no network transactions will be performed.
+     *
+     *  If no stack-specific DNS resolution is provided, the hostname
+     *  will be resolve using a UDP socket on the stack.
+     *
+     *  Call is non-blocking. Result of the DNS operation is returned by the callback.
+     *  If this function returns failure, callback will not be called. In case result
+     *  is success (IP address was found from DNS cache), callback will be called
+     *  before function returns.
+     *
+     *  @param host     Hostname to resolve
+     *  @param callback Callback that is called for result
+     *  @param interface_name  Network interface name
+     *  @param version  IP version of address to resolve, NSAPI_UNSPEC indicates
+     *                  version is chosen by the stack (defaults to NSAPI_UNSPEC)
+     *  @return         0 on immediate success,
+     *                  negative error code on immediate failure or
+     *                  a positive unique id that represents the hostname translation operation
+     *                  and can be passed to cancel
+     */
+    virtual nsapi_value_or_error_t gethostbyname_async(const char *host, hostbyname_cb_t callback, const char *interface_name,
+                                                       nsapi_version_t version = NSAPI_UNSPEC);
+
     /** Cancels asynchronous hostname translation
      *
      *  When translation is cancelled, callback will not be called.
@@ -114,9 +159,10 @@ public:
     /** Add a domain name server to list of servers to query
      *
      *  @param address  Destination for the host address
+     *  @param interface_name  Network interface name
      *  @return         NSAPI_ERROR_OK on success, negative error code on failure
      */
-    virtual nsapi_error_t add_dns_server(const SocketAddress &address);
+    virtual nsapi_error_t add_dns_server(const SocketAddress &address, const char *interface_name = NULL);
 
     /** Get a domain name server from a list of servers to query
      *
@@ -125,9 +171,10 @@ public:
      *
      *  @param index    Index of the DNS server, starts from zero
      *  @param address  Destination for the host address
+     *  @param interface_name  Network interface name
      *  @return         NSAPI_ERROR_OK on success, negative error code on failure
      */
-    virtual nsapi_error_t get_dns_server(int index, SocketAddress *address);
+    virtual nsapi_error_t get_dns_server(int index, SocketAddress *address, const char *interface_name = NULL);
 
     /*  Set stack options
      *

--- a/features/netsocket/OnboardNetworkStack.h
+++ b/features/netsocket/OnboardNetworkStack.h
@@ -91,6 +91,11 @@ public:
          */
         virtual nsapi_connection_status_t get_connection_status() const = 0;
 
+        /** Return netif interface name
+        *
+        * @return       netif name  eg "en0"
+        */
+        virtual char *get_interface_name(char *buf);
         /** Return MAC address of the network interface
          *
          * @return              MAC address as "V:W:X:Y:Z"
@@ -101,9 +106,10 @@ public:
          *
          * @param    buf        buffer to which IP address will be copied as "W:X:Y:Z"
          * @param    buflen     size of supplied buffer
+         * @param    interface_name  Network interface name
          * @return              Pointer to a buffer, or NULL if the buffer is too small
          */
-        virtual char *get_ip_address(char *buf, nsapi_size_t buflen) = 0;
+        virtual char *get_ip_address(char *buf, nsapi_size_t buflen, const char *interface_name = NULL) = 0;
 
         /** Copies netmask of the network interface to user supplied buffer
          *

--- a/features/netsocket/SocketAddress.cpp
+++ b/features/netsocket/SocketAddress.cpp
@@ -185,12 +185,12 @@ bool operator!=(const SocketAddress &a, const SocketAddress &b)
     return !(a == b);
 }
 
-void SocketAddress::_SocketAddress(NetworkStack *iface, const char *host, uint16_t port)
+void SocketAddress::_SocketAddress(NetworkStack *iface, const char *host, uint16_t port, const char *interface_name)
 {
     _ip_address = NULL;
 
     // gethostbyname must check for literals, so can call it directly
-    int err = iface->gethostbyname(host, this);
+    int err = iface->gethostbyname(host, this, interface_name);
     _port = port;
     if (err) {
         _addr = nsapi_addr_t();

--- a/features/netsocket/SocketAddress.h
+++ b/features/netsocket/SocketAddress.h
@@ -174,7 +174,7 @@ public:
     friend bool operator!=(const SocketAddress &a, const SocketAddress &b);
 
 private:
-    void _SocketAddress(NetworkStack *iface, const char *host, uint16_t port);
+    void _SocketAddress(NetworkStack *iface, const char *host, uint16_t port, const char *interface_name);
 
     mutable char *_ip_address;
     nsapi_addr_t _addr;

--- a/features/netsocket/TCPSocket.cpp
+++ b/features/netsocket/TCPSocket.cpp
@@ -110,7 +110,12 @@ nsapi_error_t TCPSocket::connect(const char *host, uint16_t port)
     if (!_socket) {
         return NSAPI_ERROR_NO_SOCKET;
     }
-    nsapi_error_t err = _stack->gethostbyname(host, &address);
+    nsapi_error_t err;
+    if (!strcmp(_interface_name, "")) {
+        err = _stack->gethostbyname(host, &address);
+    } else {
+        err = _stack->gethostbyname(host, &address, _interface_name);
+    }
     if (err) {
         return NSAPI_ERROR_DNS_FAILURE;
     }

--- a/features/netsocket/UDPSocket.cpp
+++ b/features/netsocket/UDPSocket.cpp
@@ -43,7 +43,14 @@ nsapi_error_t UDPSocket::connect(const SocketAddress &address)
 nsapi_size_or_error_t UDPSocket::sendto(const char *host, uint16_t port, const void *data, nsapi_size_t size)
 {
     SocketAddress address;
-    nsapi_size_or_error_t err = _stack->gethostbyname(host, &address);
+    nsapi_size_or_error_t err;
+
+    if (!strcmp(_interface_name, "")) {
+        err = _stack->gethostbyname(host, &address);
+    } else {
+        err = _stack->gethostbyname(host, &address, _interface_name);
+    }
+
     if (err) {
         return NSAPI_ERROR_DNS_FAILURE;
     }

--- a/features/netsocket/nsapi_dns.cpp
+++ b/features/netsocket/nsapi_dns.cpp
@@ -67,6 +67,7 @@ struct DNS_QUERY {
     nsapi_error_t status;
     NetworkStack *stack;
     char *host;
+    const char *interface_name;
     NetworkStack::hostbyname_cb_t callback;
     call_in_callback_cb_t call_in_cb;
     nsapi_size_t addr_count;
@@ -89,7 +90,7 @@ struct DNS_QUERY {
 static void nsapi_dns_cache_add(const char *host, nsapi_addr_t *address, uint32_t ttl);
 static nsapi_size_or_error_t nsapi_dns_cache_find(const char *host, nsapi_version_t version, nsapi_addr_t *address);
 
-static nsapi_error_t nsapi_dns_get_server_addr(NetworkStack *stack, uint8_t *index, uint8_t *total_attempts, uint8_t *send_success, SocketAddress *dns_addr);
+static nsapi_error_t nsapi_dns_get_server_addr(NetworkStack *stack, uint8_t *index, uint8_t *total_attempts, uint8_t *send_success, SocketAddress *dns_addr, const char *interface_name);
 
 static void nsapi_dns_query_async_create(void *ptr);
 static nsapi_error_t nsapi_dns_query_async_delete(int unique_id);
@@ -128,7 +129,7 @@ static SingletonPtr<call_in_callback_cb_t> dns_call_in;
 static bool dns_timer_running = false;
 
 // DNS server configuration
-extern "C" nsapi_error_t nsapi_dns_add_server(nsapi_addr_t addr)
+extern "C" nsapi_error_t nsapi_dns_add_server(nsapi_addr_t addr, const char *interface_name)
 {
     memmove(&dns_servers[1], &dns_servers[0],
             (DNS_SERVERS_SIZE - 1)*sizeof(nsapi_addr_t));
@@ -395,7 +396,7 @@ static nsapi_error_t nsapi_dns_cache_find(const char *host, nsapi_version_t vers
     return ret_val;
 }
 
-static nsapi_error_t nsapi_dns_get_server_addr(NetworkStack *stack, uint8_t *index, uint8_t *total_attempts, uint8_t *send_success, SocketAddress *dns_addr)
+static nsapi_error_t nsapi_dns_get_server_addr(NetworkStack *stack, uint8_t *index, uint8_t *total_attempts, uint8_t *send_success, SocketAddress *dns_addr, const char *interface_name)
 {
     bool dns_addr_set = false;
 
@@ -414,7 +415,7 @@ static nsapi_error_t nsapi_dns_get_server_addr(NetworkStack *stack, uint8_t *ind
     }
 
     if (*index < DNS_STACK_SERVERS_NUM) {
-        nsapi_error_t ret = stack->get_dns_server(*index, dns_addr);
+        nsapi_error_t ret = stack->get_dns_server(*index, dns_addr, interface_name);
         if (ret < 0) {
             *index = DNS_STACK_SERVERS_NUM;
         } else {
@@ -433,7 +434,7 @@ static nsapi_error_t nsapi_dns_get_server_addr(NetworkStack *stack, uint8_t *ind
 
 // core query function
 static nsapi_size_or_error_t nsapi_dns_query_multiple(NetworkStack *stack, const char *host,
-                                                      nsapi_addr_t *addr, unsigned addr_count, nsapi_version_t version)
+                                                      nsapi_addr_t *addr, unsigned addr_count,  const char *interface_name, nsapi_version_t version)
 {
     // check for valid host name
     int host_len = host ? strlen(host) : 0;
@@ -455,6 +456,9 @@ static nsapi_size_or_error_t nsapi_dns_query_multiple(NetworkStack *stack, const
 
     socket.set_timeout(MBED_CONF_NSAPI_DNS_RESPONSE_WAIT_TIME);
 
+    if (interface_name != NULL) {
+        socket.setsockopt(NSAPI_SOCKET, NSAPI_BIND_TO_DEVICE, interface_name, NSAPI_INTERFACE_NAME_MAX_SIZE);
+    }
     // create network packet
     uint8_t *const packet = (uint8_t *)malloc(DNS_BUFFER_SIZE);
     if (!packet) {
@@ -471,7 +475,7 @@ static nsapi_size_or_error_t nsapi_dns_query_multiple(NetworkStack *stack, const
     // check against each dns server
     while (true) {
         SocketAddress dns_addr;
-        err = nsapi_dns_get_server_addr(stack, &index, &total_attempts, &send_success, &dns_addr);
+        err = nsapi_dns_get_server_addr(stack, &index, &total_attempts, &send_success, &dns_addr, interface_name);
         if (err != NSAPI_ERROR_OK) {
             break;
         }
@@ -540,17 +544,17 @@ static nsapi_size_or_error_t nsapi_dns_query_multiple(NetworkStack *stack, const
 
 // convenience functions for other forms of queries
 extern "C" nsapi_size_or_error_t nsapi_dns_query_multiple(nsapi_stack_t *stack, const char *host,
-                                                          nsapi_addr_t *addr, nsapi_size_t addr_count, nsapi_version_t version)
+                                                          nsapi_addr_t *addr, nsapi_size_t addr_count, const char *interface_name, nsapi_version_t version)
 {
     NetworkStack *nstack = nsapi_create_stack(stack);
-    return nsapi_dns_query_multiple(nstack, host, addr, addr_count, version);
+    return nsapi_dns_query_multiple(nstack, host, addr, addr_count, interface_name, version);
 }
 
 nsapi_size_or_error_t nsapi_dns_query_multiple(NetworkStack *stack, const char *host,
-                                               SocketAddress *addresses, nsapi_size_t addr_count, nsapi_version_t version)
+                                               SocketAddress *addresses, nsapi_size_t addr_count, const char *interface_name, nsapi_version_t version)
 {
     nsapi_addr_t *addrs = new (std::nothrow) nsapi_addr_t[addr_count];
-    nsapi_size_or_error_t result = nsapi_dns_query_multiple(stack, host, addrs, addr_count, version);
+    nsapi_size_or_error_t result = nsapi_dns_query_multiple(stack, host, addrs, addr_count, interface_name, version);
 
     if (result > 0) {
         for (int i = 0; i < result; i++) {
@@ -566,7 +570,7 @@ extern "C" nsapi_error_t nsapi_dns_query(nsapi_stack_t *stack, const char *host,
                                          nsapi_addr_t *addr, nsapi_version_t version)
 {
     NetworkStack *nstack = nsapi_create_stack(stack);
-    nsapi_size_or_error_t result = nsapi_dns_query_multiple(nstack, host, addr, 1, version);
+    nsapi_size_or_error_t result = nsapi_dns_query_multiple(nstack, host, addr, 1, NULL, version);
     return (nsapi_error_t)((result > 0) ? 0 : result);
 }
 
@@ -574,7 +578,16 @@ nsapi_error_t nsapi_dns_query(NetworkStack *stack, const char *host,
                               SocketAddress *address, nsapi_version_t version)
 {
     nsapi_addr_t addr;
-    nsapi_size_or_error_t result = nsapi_dns_query_multiple(stack, host, &addr, 1, version);
+    nsapi_size_or_error_t result = nsapi_dns_query_multiple(stack, host, &addr, 1, NULL, version);
+    address->set_addr(addr);
+    return (nsapi_error_t)((result > 0) ? 0 : result);
+}
+
+nsapi_error_t nsapi_dns_query(NetworkStack *stack, const char *host,
+                              SocketAddress *address, const char *interface_name, nsapi_version_t version)
+{
+    nsapi_addr_t addr;
+    nsapi_size_or_error_t result = nsapi_dns_query_multiple(stack, host, &addr, 1, interface_name, version);
     address->set_addr(addr);
     return (nsapi_error_t)((result > 0) ? 0 : result);
 }
@@ -583,7 +596,14 @@ nsapi_value_or_error_t nsapi_dns_query_async(NetworkStack *stack, const char *ho
                                              NetworkStack::hostbyname_cb_t callback, call_in_callback_cb_t call_in_cb,
                                              nsapi_version_t version)
 {
-    return nsapi_dns_query_multiple_async(stack, host, callback, 0, call_in_cb, version);
+    return nsapi_dns_query_multiple_async(stack, host, callback, 0, call_in_cb, NULL, version);
+}
+
+nsapi_value_or_error_t nsapi_dns_query_async(NetworkStack *stack, const char *host,
+                                             NetworkStack::hostbyname_cb_t callback, call_in_callback_cb_t call_in_cb,
+                                             const char *interface_name, nsapi_version_t version)
+{
+    return nsapi_dns_query_multiple_async(stack, host, callback, 0, call_in_cb, interface_name, version);
 }
 
 void nsapi_dns_call_in_set(call_in_callback_cb_t callback)
@@ -603,7 +623,7 @@ nsapi_error_t nsapi_dns_call_in(call_in_callback_cb_t cb, int delay, mbed::Callb
 
 nsapi_value_or_error_t nsapi_dns_query_multiple_async(NetworkStack *stack, const char *host,
                                                       NetworkStack::hostbyname_cb_t callback, nsapi_size_t addr_count,
-                                                      call_in_callback_cb_t call_in_cb, nsapi_version_t version)
+                                                      call_in_callback_cb_t call_in_cb, const char *interface_name, nsapi_version_t version)
 {
     dns_mutex->lock();
 
@@ -672,6 +692,12 @@ nsapi_value_or_error_t nsapi_dns_query_multiple_async(NetworkStack *stack, const
     query->total_timeout = MBED_CONF_NSAPI_DNS_TOTAL_ATTEMPTS * MBED_CONF_NSAPI_DNS_RESPONSE_WAIT_TIME + 500;
     query->count = 0;
     query->state = DNS_CREATED;
+
+    if (interface_name == NULL) {
+        query->interface_name = NULL;
+    } else {
+        query->interface_name = interface_name;
+    }
 
     query->unique_id = dns_unique_id++;
     if (query->unique_id > 0x7FFF) {
@@ -870,6 +896,9 @@ static void nsapi_dns_query_async_create(void *ptr)
         }
 
         socket->set_timeout(0);
+        if (query->interface_name != NULL) {
+            socket->setsockopt(NSAPI_SOCKET, NSAPI_BIND_TO_DEVICE, query->interface_name, NSAPI_INTERFACE_NAME_MAX_SIZE);
+        }
 
         if (!query->socket_cb_data) {
             query->socket_cb_data = new SOCKET_CB_DATA;
@@ -988,7 +1017,7 @@ static void nsapi_dns_query_async_send(void *ptr)
 
     while (true) {
         SocketAddress dns_addr;
-        nsapi_size_or_error_t err = nsapi_dns_get_server_addr(query->stack, &(query->dns_server), &(query->total_attempts), &(query->send_success), &dns_addr);
+        nsapi_size_or_error_t err = nsapi_dns_get_server_addr(query->stack, &(query->dns_server), &(query->total_attempts), &(query->send_success), &dns_addr, query->interface_name);
         if (err != NSAPI_ERROR_OK) {
             nsapi_dns_query_async_resp(query, NSAPI_ERROR_TIMEOUT, NULL);
             free(packet);

--- a/features/netsocket/nsapi_dns.h
+++ b/features/netsocket/nsapi_dns.h
@@ -58,7 +58,7 @@ nsapi_size_or_error_t nsapi_dns_query_multiple(nsapi_stack_t *stack, const char 
  *  @param addr     Destination for the host address
  *  @return         0 on success, negative error code on failure
  */
-nsapi_error_t nsapi_dns_add_server(nsapi_addr_t addr);
+nsapi_error_t nsapi_dns_add_server(nsapi_addr_t addr, const char *interface_name);
 
 
 #else
@@ -77,6 +77,20 @@ typedef mbed::Callback<nsapi_error_t (int delay_ms, mbed::Callback<void()> user_
 nsapi_error_t nsapi_dns_query(NetworkStack *stack, const char *host,
                               SocketAddress *addr, nsapi_version_t version = NSAPI_IPv4);
 
+/** Query a domain name server for an IP address of a given hostname using Network interface name
+ *
+ *  @param stack    Network stack as target for DNS query
+ *  @param host     Hostname to resolve
+ *  @param addr     Destination for the host address
+ *  @param interface_name Network interface name
+ *  @param version  IP version to resolve (defaults to NSAPI_IPv4)
+ *  @return         0 on success, negative error code on failure
+ *                  NSAPI_ERROR_DNS_FAILURE indicates the host could not be found
+ */
+nsapi_error_t nsapi_dns_query(NetworkStack *stack, const char *host,
+                              SocketAddress *addr, const char *interface_name, nsapi_version_t version = NSAPI_IPv4);
+
+
 /** Query a domain name server for an IP address of a given hostname
  *
  *  @param stack    Network stack as target for DNS query
@@ -90,6 +104,21 @@ nsapi_error_t nsapi_dns_query(NetworkStack *stack, const char *host,
 nsapi_error_t nsapi_dns_query_async(NetworkStack *stack, const char *host,
                                     NetworkStack::hostbyname_cb_t callback, call_in_callback_cb_t call_in_cb,
                                     nsapi_version_t version = NSAPI_IPv4);
+
+/** Query a domain name server for an IP address of a given hostname using Network interface name
+ *
+ *  @param stack    Network stack as target for DNS query
+ *  @param host     Hostname to resolve
+ *  @param callback Callback that is called for result
+ *  @param interface_name Network interface name
+ *  @param version  IP version to resolve (defaults to NSAPI_IPv4)
+ *  @return         0 on success, negative error code on failure or an unique id that
+ *                  represents the hostname translation operation and can be passed to
+ *                  cancel, NSAPI_ERROR_DNS_FAILURE indicates the host could not be found
+ */
+nsapi_error_t nsapi_dns_query_async(NetworkStack *stack, const char *host,
+                                    NetworkStack::hostbyname_cb_t callback, call_in_callback_cb_t call_in_cb,
+                                    const char *interface_name, nsapi_version_t version = NSAPI_IPv4);
 
 /** Query a domain name server for an IP address of a given hostname (asynchronous)
  *
@@ -130,7 +159,7 @@ nsapi_error_t nsapi_dns_query(S *stack, const char *host,
  *                    NSAPI_ERROR_DNS_FAILURE indicates the host could not be found
  */
 nsapi_size_or_error_t nsapi_dns_query_multiple(NetworkStack *stack, const char *host,
-                                               SocketAddress *addr, nsapi_size_t addr_count, nsapi_version_t version = NSAPI_IPv4);
+                                               SocketAddress *addr, nsapi_size_t addr_count,  const char *interface_name, nsapi_version_t version = NSAPI_IPv4);
 
 /** Query a domain name server for an IP address of a given hostname (asynchronous)
  *
@@ -145,7 +174,7 @@ nsapi_size_or_error_t nsapi_dns_query_multiple(NetworkStack *stack, const char *
  */
 nsapi_size_or_error_t nsapi_dns_query_multiple_async(NetworkStack *stack, const char *host,
                                                      NetworkStack::hostbyname_cb_t callback, nsapi_size_t addr_count,
-                                                     call_in_callback_cb_t call_in_cb, nsapi_version_t version = NSAPI_IPv4);
+                                                     call_in_callback_cb_t call_in_cb, const char *interface_name, nsapi_version_t version = NSAPI_IPv4);
 
 /** Query a domain name server for multiple IP address of a given hostname
  *
@@ -158,7 +187,7 @@ nsapi_size_or_error_t nsapi_dns_query_multiple_async(NetworkStack *stack, const 
  *                    NSAPI_ERROR_DNS_FAILURE indicates the host could not be found
  */
 extern "C" nsapi_size_or_error_t nsapi_dns_query_multiple(nsapi_stack_t *stack, const char *host,
-                                                          nsapi_addr_t *addr, nsapi_size_t addr_count, nsapi_version_t version = NSAPI_IPv4);
+                                                          nsapi_addr_t *addr, nsapi_size_t addr_count, const char *interface_name, nsapi_version_t version = NSAPI_IPv4);
 
 
 /** Query a domain name server for multiple IP address of a given hostname
@@ -203,16 +232,16 @@ void nsapi_dns_call_in_set(call_in_callback_cb_t callback);
  *  @param addr     Destination for the host address
  *  @return         0 on success, negative error code on failure
  */
-extern "C" nsapi_error_t nsapi_dns_add_server(nsapi_addr_t addr);
+extern "C" nsapi_error_t nsapi_dns_add_server(nsapi_addr_t addr, const char *interface_name);
 
 /** Add a domain name server to list of servers to query
  *
  *  @param addr     Destination for the host address
  *  @return         0 on success, negative error code on failure
  */
-static inline nsapi_error_t nsapi_dns_add_server(const SocketAddress &address)
+static inline nsapi_error_t nsapi_dns_add_server(const SocketAddress &address, const char *interface_name)
 {
-    return nsapi_dns_add_server(address.get_addr());
+    return nsapi_dns_add_server(address.get_addr(), interface_name);
 }
 
 /** Add a domain name server to list of servers to query
@@ -220,9 +249,9 @@ static inline nsapi_error_t nsapi_dns_add_server(const SocketAddress &address)
  *  @param addr     Destination for the host address
  *  @return         0 on success, negative error code on failure
  */
-static inline nsapi_error_t nsapi_dns_add_server(const char *address)
+static inline nsapi_error_t nsapi_dns_add_server(const char *address, const char *interface_name)
 {
-    return nsapi_dns_add_server(SocketAddress(address));
+    return nsapi_dns_add_server(SocketAddress(address), interface_name);
 }
 
 

--- a/features/netsocket/nsapi_types.h
+++ b/features/netsocket/nsapi_types.h
@@ -127,9 +127,13 @@ typedef enum nsapi_security {
     NSAPI_SECURITY_UNKNOWN      = 0xFF,     /*!< unknown/unsupported security in scan results */
 } nsapi_security_t;
 
-/** Maximum size of network interface name
+/** Size of shortened network interface name
  */
 #define NSAPI_INTERFACE_NAME_SIZE 2
+
+/** Maximum size of network interface name
+ */
+#define NSAPI_INTERFACE_NAME_MAX_SIZE 4
 
 /** Maximum size of IP address representation
  */
@@ -258,6 +262,7 @@ typedef enum nsapi_socket_option {
     NSAPI_RCVBUF,            /*!< Sets recv buffer size */
     NSAPI_ADD_MEMBERSHIP,    /*!< Add membership to multicast address */
     NSAPI_DROP_MEMBERSHIP,   /*!< Drop membership to multicast address */
+    NSAPI_BIND_TO_DEVICE,        /*!< Bind socket network interface name*/
 } nsapi_socket_option_t;
 
 /** Supported IP protocol versions of IP stack


### PR DESCRIPTION
ONME-3862  Change lwip DNS functionality so that only default network interface updates DNS addresses in lwip global DNS storage

### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ x] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

